### PR TITLE
👷 build: update Node.js runtime requirement to v22

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,11 @@
 {
   "name": "mr-stick-vite",
   "private": true,
-  "version": "0.0.0",
+  "version": "1.0.1",
   "type": "module",
+  "engines": {
+    "node": ">=22.0.0"
+  },
   "scripts": {
     "dev": "vite",
     "build": "vite build",


### PR DESCRIPTION
What changed:
- engines.node: '>=18.0.0' → '>=22.0.0'

Why:
- Node.js 18 enters maintenance mode and will be deprecated on Vercel
- Ensures continued security updates and platform compatibility
- Proactive migration before September 2025 EOL deadline

Impact:
- Vercel deployments will now use Node.js 22.x runtime
- No breaking changes expected with current dependency stack
- Astro 5.11+ and React 19.1+ fully support Node.js 22